### PR TITLE
qos/controller: introduce qos/controller.Controller

### DIFF
--- a/pkg/qos/context.go
+++ b/pkg/qos/context.go
@@ -1,0 +1,27 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package qos
+
+import "context"
+
+type levelContextKey struct{}
+
+// LevelFromContext extracts a Level from the passed context.
+func LevelFromContext(ctx context.Context) (Level, bool) {
+	l, ok := ctx.Value(levelContextKey{}).(Level)
+	return l, ok
+}
+
+// ContextWithLevel returns a context which is a child of ctx storing l to be
+// extracted later with LevelFromContext.
+func ContextWithLevel(ctx context.Context, l Level) context.Context {
+	return context.WithValue(ctx, levelContextKey{}, l)
+}

--- a/pkg/qos/controller/controller.go
+++ b/pkg/qos/controller/controller.go
@@ -1,0 +1,603 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/qos"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"golang.org/x/perf/benchstat"
+)
+
+// Controller keeps track of the allowed level for requests.
+// It stores a current admission level and decides whether requests can be
+// admitted.
+// In order to make this decision the controller needs to tick every so often.
+type Controller struct {
+	cfg     Config
+	metrics Metrics
+
+	mu struct {
+		syncutil.RWMutex
+		tickCond  sync.Cond
+		blockCond sync.Cond
+
+		nextTick time.Time
+		ticks    int
+
+		admissionLevel qos.Level
+		rejectionLevel qos.Level
+		rejectionOn    bool
+
+		numAdmitted     int64
+		numBlocked      int64
+		numBlockWaiting int64
+		numCanceled     int64
+		numRejected     int64
+
+		admitHist  histogram
+		wq         waitQueue
+		rejectHist histogram
+	}
+}
+
+// TODO(ajwerner): justify these, they're taken from the DAGOR paper and cut
+// in half.
+const (
+	defaultMaxReqsPerInterval = 2000
+	defaultTickInterval       = time.Second
+	defaultPruneRate          = .05
+	defaultGrowRate           = .01
+	defaultMaxBlocked         = 1000
+)
+
+// Config configures a controller.
+type Config struct {
+
+	// Name is used to generate metrics and for logging.
+	Name string
+
+	// MaxReqsPerInterval is the maximum number of requests which can occur in
+	// an interval. If this number is exceeded a tick will occur.
+	MaxReqsPerInterval int
+
+	// TickInterval is the maximum amount of time between ticks.
+	// Ticks may also occur if the maximum number of requests per interval
+	// is exceeded.
+	TickInterval time.Duration
+
+	// RandomizationFactor controls the percent by which TickInterval should be
+	// purturbed. The true time interval will be
+	//
+	//   TickInterval*(1 +/- RandomizationFactor)
+	//
+	RandomizationFactor float64
+
+	// OverloadSignal is used during ticks to determine whether the admission
+	// level should rise or fall. To keep the level the same return (true, cur).
+	OverloadSignal func(cur qos.Level) (overloaded bool, max qos.Level)
+
+	// ScaleFactor is used weigh requests at a given level.
+	// This is useful when requests of different classes may not be of equal cost.
+	ScaleFactor func(qos.Class) int64
+
+	// MaxBlocked determines the maximum number of requests which may be blocked.
+	// If a request would lead to more than this number of requests being blocked
+	// the rejection level will increase.
+	MaxBlocked int64
+
+	// The PruneRate and GrowRate work by examining the traffic which occurred
+	// in the previous interval scaled by the scale factor and then moving the
+	// admission level up or down to match the new target.
+
+	// PruneRate determines the rate at which traffic will be pruned when the
+	// system is overloaded.
+	PruneRate float64
+
+	// PruneRate determines the rate at which traffic will add when the system
+	// is not overloaded.
+	GrowRate float64
+}
+
+func defaultSizeFactor(_ qos.Class) int64 { return 1 }
+
+func (cfg *Config) setDefaults() {
+	if cfg.TickInterval <= 0 {
+		cfg.TickInterval = defaultTickInterval
+	}
+	if cfg.PruneRate <= 0 {
+		cfg.PruneRate = defaultPruneRate
+	}
+	if cfg.GrowRate <= 0 {
+		cfg.GrowRate = defaultGrowRate
+	}
+	if cfg.MaxBlocked <= 0 {
+		cfg.MaxBlocked = defaultMaxBlocked
+	}
+	if cfg.MaxReqsPerInterval <= 0 {
+		cfg.MaxReqsPerInterval = defaultMaxReqsPerInterval
+	}
+	if cfg.ScaleFactor == nil {
+		cfg.ScaleFactor = defaultSizeFactor
+	}
+}
+
+// NewController constructs a new Controller with the specified Config.
+// If the stopper is non-nil it will be used to Admit a request at the maximum
+// qos.Level every cfg.TickInterval in order to ensure that the Controller's
+// state continue to update in the absence of traffic.
+//
+// TODO(ajwerner): remove this hacky goroutine.
+func NewController(ctx context.Context, stopper *stop.Stopper, cfg Config) *Controller {
+	cfg.setDefaults()
+
+	c := &Controller{cfg: cfg}
+	c.metrics = makeMetrics(cfg.Name)
+	c.mu.tickCond.L = c.mu.RLocker()
+	c.mu.blockCond.L = c.mu.RLocker()
+	c.mu.admissionLevel = minLevel
+	c.mu.rejectionLevel = minLevel
+	initWaitQueue(&c.mu.wq)
+	if stopper != nil {
+		if err := stopper.RunAsyncTask(ctx, cfg.Name+"admission.controller.ticker", func(ctx context.Context) {
+			t := timeutil.NewTimer()
+			for {
+				t.Reset(c.cfg.TickInterval)
+				select {
+				case <-stopper.ShouldQuiesce():
+					return
+				case <-ctx.Done():
+					return
+				case <-t.C:
+					t.Read = true
+					_ = c.Admit(ctx, maxLevel)
+				}
+			}
+		}); err != nil {
+			panic(err)
+		}
+	}
+	return c
+}
+
+// Metrics returns a metrics struct for this Controller.
+func (c *Controller) Metrics() *Metrics {
+	return &c.metrics
+}
+
+// AdmissionLevel returns the current admission level.
+func (c *Controller) AdmissionLevel() qos.Level {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.mu.admissionLevel
+}
+
+// RejectionLevel returns the current rejection level.
+func (c *Controller) RejectionLevel() qos.Level {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.mu.rejectionLevel
+}
+
+// ErrRejected is returned from AdmitAt if the rejection level reaches or
+// surpasses the level of the request.
+var ErrRejected = errors.New("rejected")
+
+// String returns a detailed string representation of the Controller.
+//
+// The representation shows for each Class, for each non-empty Shard the number
+// of requests incident on that Level. The AdmissionLevel is represented as ➡
+// and the rejection level (if it exists) is represented as ⇨. The numbers at
+// or above the rejection level correspond to requests which have been admitted
+// in the current interval. The requests between the admission and rejection
+// levels represent the number of requests currently blocked at that level and
+// the numbers at or below the rejection level represent the requests which have
+// been rejected in this interval.
+//
+// Below is an example of the output:
+//
+//   	---|  h   |  d   |  l   |
+//   	127|  0.00|  1.00|  0.00|
+//   	...
+//   	10 |  0.00|  0.00|  100 |
+//   	9  |  0.00|  0.00|  100 |
+//   	8  |  0.00|  0.00|  100 |
+//   	7  |  0.00|  0.00|  100 |
+//   	6  |  0.00|  0.00|  100 |
+//   	5  |  0.00|  0.00|  100 |
+//   	4  |  0.00|  0.00|  100 |
+//   	3  |  0.00|  0.00|  100 |
+//   	2  |  0.00|  0.00|  100 |
+//   	1  |  0.00|➡ 100 |⇨ 100 |
+//   	0  |  0.00|  99.0|  0.00|
+//   	int: 3; ad: 101; bl: 999; rej: 100
+//
+func (c *Controller) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.stringRLocked()
+}
+
+func (c *Controller) stringRLocked() string {
+	var b strings.Builder
+	b.WriteString("---")
+	for _, cl := range qos.Classes() {
+		b.WriteString("|  ")
+		b.WriteString(cl.String())
+		b.WriteString("   ")
+	}
+	b.WriteString("|\n")
+	var skipped bool
+	for _, s := range qos.Shards() {
+		if s < qos.NumShards-1 &&
+			s > 0 &&
+			c.mu.admissionLevel.Shard != s &&
+			c.mu.rejectionLevel.Shard != s &&
+			c.mu.admitHist.emptyAtShard(s) &&
+			c.mu.wq.emptyAtShard(s) {
+			skipped = true
+			continue
+		} else if skipped {
+			skipped = false
+			b.WriteString("...\n")
+		}
+		_, _ = fmt.Fprintf(&b, "%-3d|", s)
+		for _, cl := range qos.Classes() {
+			p := qos.Level{cl, s}
+			pad := "  "
+			if c.mu.admissionLevel == p {
+				pad = "\u27a1 "
+			} else if c.mu.rejectionOn && c.mu.rejectionLevel == p {
+				pad = "\u21e8 "
+			}
+			var v float64
+			switch {
+			case !p.Less(c.mu.admissionLevel):
+				v = float64(atomic.LoadUint64(&c.mu.admitHist.counters[cl][s]))
+			case !c.mu.rejectionOn || c.mu.rejectionLevel.Less(p):
+				lq := c.mu.wq.lq(p)
+				v = float64(lq.len())
+			default:
+				v = float64(atomic.LoadUint64(&c.mu.rejectHist.counters[cl][s]))
+			}
+			_, _ = fmt.Fprintf(&b, "%s%-4v|", pad, benchstat.NewScaler(v, "")(v))
+		}
+		b.WriteString("\n")
+	}
+	_, _ = fmt.Fprintf(&b, "int: %d; ad: %d; bl: %d; rej: %d",
+		c.mu.ticks,
+		atomic.LoadInt64(&c.mu.numAdmitted),
+		atomic.LoadInt64(&c.mu.numBlocked)-atomic.LoadInt64(&c.mu.numCanceled),
+		atomic.LoadInt64(&c.mu.numRejected))
+	return b.String()
+}
+
+func (c *Controller) maybeTickRLocked(now time.Time) {
+	if now.Before(c.mu.nextTick) {
+		return
+	}
+	c.mu.RUnlock()
+	defer c.mu.RLock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if now.Before(c.mu.nextTick) {
+		return
+	}
+	c.tickLocked(now)
+}
+
+// Admit is a shorthand for c.AdmitAt(ctx, p, timeutil.Now()).
+func (c *Controller) Admit(ctx context.Context, p qos.Level) error {
+	return c.AdmitAt(ctx, p, timeutil.Now())
+}
+
+// AdmitAt attempts to admit a request at the specified level and time.
+// Admit at may return ErrRejected if the rejection level at any point rises to
+// or above l. Context cancellations will also propagate an error.
+func (c *Controller) AdmitAt(ctx context.Context, l qos.Level, now time.Time) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if log.V(3) {
+		log.Infof(ctx, "attempting to admit %d@%d: %v %v", l, now.Unix(), c.mu.admissionLevel, c.mu.nextTick.Sub(now))
+	}
+	c.maybeTickRLocked(now)
+	if l.Class != qos.ClassHigh {
+		for l.Less(c.mu.admissionLevel) {
+			// Reject requests which are at or below the current rejection level.
+			if c.mu.rejectionLevel != minLevel && !c.mu.rejectionLevel.Less(l) {
+				atomic.AddInt64(&c.mu.numRejected, 1)
+				c.mu.rejectHist.record(l, 1)
+				return ErrRejected
+			}
+			if numBlocked := atomic.AddInt64(&c.mu.numBlocked, 1); numBlocked == c.cfg.MaxBlocked+1 {
+				c.raiseRejectionLevelRLocked(l)
+				continue
+			} else if numBlocked > c.cfg.MaxBlocked {
+				atomic.AddInt64(&c.mu.numBlockWaiting, 1)
+				c.mu.blockCond.Wait()
+				continue
+			}
+			c.metrics.NumBlocked.Inc(1)
+			waitErr := c.waitRLocked(ctx, l)
+			if waitErr == nil {
+				c.metrics.NumUnblocked.Inc(1)
+			} else {
+				atomic.AddInt64(&c.mu.numCanceled, 1)
+				return waitErr
+			}
+		}
+	}
+	defer c.mu.admitHist.record(l, 1)
+	numAdmitted := atomic.AddInt64(&c.mu.numAdmitted, 1)
+	for numAdmitted > int64(c.cfg.MaxReqsPerInterval) {
+		if numAdmitted == (int64(c.cfg.MaxReqsPerInterval) + 1) {
+			c.tickRLocked(now)
+		} else {
+			c.mu.tickCond.Wait()
+		}
+		// c was just ticked so we add ourselves again
+		numAdmitted = atomic.AddInt64(&c.mu.numAdmitted, 1)
+	}
+	return nil
+}
+
+func (c *Controller) tickRLocked(now time.Time) {
+	c.mu.RUnlock()
+	defer c.mu.RLock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.tickLocked(now)
+}
+
+func randomizeInterval(d time.Duration, factor float64) time.Duration {
+	r := (2*rand.Float64() - 1) * factor
+	dd := time.Duration(float64(d) * (1 + r))
+	return dd
+}
+
+func (c *Controller) tickLocked(now time.Time) {
+	defer c.mu.tickCond.Broadcast()
+	c.mu.ticks++
+	interval := randomizeInterval(c.cfg.TickInterval, c.cfg.RandomizationFactor)
+	before := c.stringRLocked()
+	c.mu.nextTick = now.Add(interval)
+	numAdmitted := atomic.SwapInt64(&c.mu.numAdmitted, 0)
+	prev := c.mu.admissionLevel
+	overloaded, max := c.cfg.OverloadSignal(prev)
+	if overloaded {
+		c.metrics.Inc.Inc(1)
+		c.raiseAdmissionLevelLocked(max)
+	} else if c.mu.admissionLevel != minLevel {
+		c.metrics.Dec.Inc(1)
+		freed := c.lowerAdmissionLevelLocked()
+		numCanceled := atomic.SwapInt64(&c.mu.numCanceled, 0)
+		unblocked := int64(freed) + numCanceled
+		numBlocked := atomic.AddInt64(&c.mu.numBlocked, -1*unblocked)
+		c.metrics.CurNumBlocked.Update(numBlocked)
+		if numBlocked < c.cfg.MaxBlocked/2 {
+			c.mu.rejectionLevel = minLevel
+			c.mu.rejectionOn = false
+		}
+	}
+	if log.V(1) {
+		log.Infof(context.TODO(), "tick %v: overload %v (%d) prev %v next %v\n%v",
+			now.Unix(), overloaded, numAdmitted, prev, c.mu.admissionLevel, before)
+	}
+	c.mu.admitHist = histogram{}
+	c.metrics.AdmissionLevel.Update(int64(c.mu.admissionLevel.Encode()))
+	if c.mu.rejectionOn {
+		c.metrics.RejectionLevel.Update(int64(c.mu.rejectionLevel.Encode()))
+	} else {
+		c.metrics.RejectionLevel.Update(0)
+	}
+	c.metrics.NumTicks.Inc(1)
+}
+
+var maxLevel = qos.Level{qos.ClassHigh, qos.NumShards - 1}
+var minLevel = qos.Level{qos.ClassLow, 0}
+
+func (c *Controller) raiseAdmissionLevelLocked(max qos.Level) {
+	if c.mu.admissionLevel == max {
+		return
+	}
+	cur := c.mu.admissionLevel
+	sizeFactor, total := admittedAbove(cur, &c.mu.admitHist, c.cfg.ScaleFactor)
+	target := int64(float64(total) * (1 - c.cfg.PruneRate))
+	prev, cur := cur, cur.Inc()
+	for ; cur.Less(max) && cur.Class != qos.ClassHigh; prev, cur = cur, cur.Inc() {
+		if log.V(2) {
+			log.Infof(context.Background(), "raise %v %v %v", cur, total, target)
+		}
+		if total <= target {
+			break
+		}
+		if cur.Class != prev.Class {
+			sizeFactor = c.cfg.ScaleFactor(cur.Class)
+		}
+		total -= int64(c.mu.admitHist.countAt(cur)) * sizeFactor
+	}
+	c.mu.admissionLevel = cur
+}
+
+// findLowerLevelLocked computes the new level for the Controller
+// given the activity of the last interval. It does not modify c other
+// than by calling into the waitQueue.
+//
+// TODO(ajwerner): meter releasing requests.
+func (c *Controller) lowerAdmissionLevelLocked() (freed int) {
+	prev := c.mu.admissionLevel
+	cur := prev.Dec()
+	sizeFactor, total := admittedAbove(cur, &c.mu.admitHist, c.cfg.ScaleFactor)
+	target := int64(float64(total)*(1+c.cfg.GrowRate)) + 1
+	for ; cur != minLevel; prev, cur = cur, cur.Dec() {
+		if cur.Class != prev.Class {
+			sizeFactor = c.cfg.ScaleFactor(cur.Class)
+		}
+		released := c.releaseLevelLocked(cur)
+		freed += released
+		if released == 0 {
+			released++
+		}
+		if total += int64(released) * sizeFactor; total >= target {
+			break
+		}
+	}
+	c.mu.admissionLevel = cur
+	return freed
+}
+
+func (c *Controller) raiseRejectionLevelRLocked(l qos.Level) {
+	defer c.mu.blockCond.Broadcast()
+	c.mu.RUnlock()
+	defer c.mu.RLock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r := c.mu.rejectionLevel
+	blocked := atomic.LoadInt64(&c.mu.numBlocked)
+	blockWaiting := atomic.LoadInt64(&c.mu.numBlockWaiting)
+	canceled := atomic.SwapInt64(&c.mu.numCanceled, 0)
+	blocked -= blockWaiting
+	blocked -= canceled
+	for blocked > c.cfg.MaxBlocked {
+		if !c.mu.rejectionOn {
+			c.mu.rejectionOn = true
+		} else {
+			r = r.Inc()
+		}
+		blocked -= int64(c.releaseLevelLocked(r))
+		c.mu.rejectionLevel = r
+	}
+	blocked-- // count this one
+	atomic.StoreInt64(&c.mu.numBlocked, blocked)
+	atomic.StoreInt64(&c.mu.numBlockWaiting, 0)
+}
+
+func (c *Controller) waitRLocked(ctx context.Context, l qos.Level) (err error) {
+	lq := c.mu.wq.lq(l)
+	atomic.AddInt64(&lq.numWaiting, 1)
+	seq := lq.seq
+	ch := lq.freed
+	c.mu.RUnlock()
+	defer func() {
+		c.mu.RLock()
+		if err != nil && lq.seq == seq {
+			atomic.AddInt64(&lq.numCanceled, 1)
+		}
+	}()
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *Controller) releaseLevelLocked(l qos.Level) (freed int) {
+	lq := c.mu.wq.lq(l)
+	if log.V(1) {
+		log.Infof(context.TODO(), "releasing %v", l, lq.len())
+	}
+	if lLen := lq.len(); lLen > 0 {
+		freed = int(lLen)
+		close(lq.freed)
+		lq.freed = make(chan struct{})
+		atomic.StoreInt64(&lq.numWaiting, 0)
+		atomic.StoreInt64(&lq.numCanceled, 0)
+		lq.seq++
+	}
+	return freed
+}
+
+func admittedAbove(
+	l qos.Level, h *histogram, sizeFactor func(qos.Class) int64,
+) (factor, count int64) {
+	prev, cur, factor := maxLevel, maxLevel, sizeFactor(qos.ClassHigh)
+	for ; l.Less(cur); cur, prev = cur.Dec(), cur {
+		if cur.Class != prev.Class {
+			factor = sizeFactor(cur.Class)
+		}
+		count += factor * int64(atomic.LoadUint64(&h.counters[cur.Class][cur.Shard]))
+	}
+	return factor, count
+}
+
+type waitQueue [qos.NumClasses][qos.NumShards]waitLevel
+
+type waitLevel struct {
+	numWaiting  int64
+	numCanceled int64
+	freed       chan struct{}
+	seq         int
+}
+
+func initWaitQueue(q *waitQueue) {
+	for c := range q {
+		for s := range q[c] {
+			q[c][s] = waitLevel{
+				freed: make(chan struct{}),
+			}
+		}
+	}
+}
+
+// len is safe to call concurrently but generally is not.
+func (wl *waitLevel) len() int64 {
+	w, c := atomic.LoadInt64(&wl.numWaiting), atomic.LoadInt64(&wl.numCanceled)
+	return w - c
+}
+
+func (q *waitQueue) lq(l qos.Level) *waitLevel {
+	return &q[l.Class][l.Shard]
+}
+
+func (q *waitQueue) emptyAtShard(s qos.Shard) bool {
+	for c := qos.Class(0); c < qos.NumClasses; c++ {
+		if q.lq(qos.Level{c, s}).len() > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+type histogram struct {
+	counters [qos.NumClasses][qos.NumShards]uint64
+}
+
+func (h *histogram) emptyAtShard(s qos.Shard) bool {
+	for cl := 0; cl < qos.NumClasses; cl++ {
+		if atomic.LoadUint64(&h.counters[cl][s]) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (h *histogram) countAt(p qos.Level) uint64 {
+	return atomic.LoadUint64(&h.counters[p.Class][p.Shard])
+}
+
+func (h *histogram) record(p qos.Level, c uint64) {
+	atomic.AddUint64(&h.counters[p.Class][p.Shard], c)
+}

--- a/pkg/qos/controller/controller_test.go
+++ b/pkg/qos/controller/controller_test.go
@@ -1,0 +1,359 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt and at www.mariadb.com/bsl11.
+//
+// Change Date: 2022-10-01
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt and at
+// https://www.apache.org/licenses/LICENSE-2.0
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/qos"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/assert"
+)
+
+var testConfig = Config{
+	Name:         "test",
+	TickInterval: time.Second,
+	MaxBlocked:   1000,
+	GrowRate:     .01,
+	PruneRate:    .05,
+}
+
+var (
+	t0 = time.Unix(0, 0)
+	t1 = time.Unix(1, 0)
+	t2 = time.Unix(2, 0)
+	t3 = time.Unix(3, 0)
+	t4 = time.Unix(4, 0)
+)
+
+var (
+	lh0   = qos.Level{qos.ClassHigh, 0}
+	lh127 = qos.Level{qos.ClassHigh, 127}
+
+	ld0   = qos.Level{qos.ClassDefault, 0}
+	ld1   = qos.Level{qos.ClassDefault, 1}
+	ld10  = qos.Level{qos.ClassDefault, 10}
+	ld127 = qos.Level{qos.ClassDefault, 127}
+
+	ll0   = qos.Level{qos.ClassLow, 0}
+	ll1   = qos.Level{qos.ClassLow, 1}
+	ll10  = qos.Level{qos.ClassLow, 10}
+	ll127 = qos.Level{qos.ClassLow, 127}
+)
+
+func TestAdmissionController(t *testing.T) {
+	var overloaded atomic.Value
+	overloaded.Store(false)
+	ctx := context.Background()
+	cfg := testConfig
+	cfg.OverloadSignal = func(qos.Level) (bool, qos.Level) {
+		return overloaded.Load().(bool), lh127
+	}
+	c := NewController(ctx, nil, cfg)
+	assert.Equal(t, minLevel, c.AdmissionLevel())
+	assert.Nil(t, c.AdmitAt(ctx, ld0, t1))
+	assert.Nil(t, c.AdmitAt(ctx, ld127, t1))
+	overloaded.Store(true)
+	errCh := make(chan error)
+	assertBlocks := func(ctx context.Context, l qos.Level, ts time.Time) {
+		go func() { errCh <- c.AdmitAt(ctx, l, ts) }()
+		const waitForError = 5 * time.Millisecond
+		select {
+		case err := <-errCh:
+			t.Fatalf("expected the request to block and not to recieve an error, got %v", err)
+		case <-time.After(waitForError):
+		}
+	}
+	assertBlocks(ctx, ld0, t2)
+	assert.Nil(t, c.AdmitAt(ctx, lh0, t2))
+	assert.Equal(t, ld1, c.AdmissionLevel())
+	overloaded.Store(false)
+	// Ensure that the maximum admission level never gets blocked.
+	assert.Nil(t, c.AdmitAt(ctx, lh127, t2))
+	// Admit again and ensure that the admission level decreases, unblocking the
+	// previously blocked goroutine.
+	assert.Nil(t, c.AdmitAt(ctx, ld127, t3))
+	assert.Nil(t, <-errCh)
+	assert.Equal(t, ld0, c.AdmissionLevel())
+}
+
+func ExampleController_cancel() {
+	var overloaded atomic.Value
+	overloaded.Store(false)
+	cfg := testConfig
+	cfg.OverloadSignal = func(qos.Level) (bool, qos.Level) {
+		return overloaded.Load().(bool), maxLevel
+	}
+	ctx := context.Background()
+	c := NewController(ctx, nil, cfg)
+	fmt.Println("The controller begins at the lowest level.")
+	fmt.Println(c)
+	t0 := time.Unix(0, 0)
+	fmt.Println()
+	fmt.Println("Three requests come in and succeed in the current interval.")
+	fmt.Printf("AdmitAt(%v, %s) = %v.\n", ld127, t0.Format("0.0"), c.AdmitAt(ctx, ld127, t0))
+	fmt.Printf("AdmitAt(%v, %s) = %v.\n", ld0, t0.Format("0.0"), c.AdmitAt(ctx, ld0, t0))
+	fmt.Printf("AdmitAt(%v, %s) = %v.\n", ld1, t0.Format("0.0"), c.AdmitAt(ctx, ld1, t0))
+	fmt.Println(c)
+	fmt.Println()
+	fmt.Println("The overload signal becomes true and time advances to 0.1.")
+	overloaded.Store(true)
+	t1 := time.Unix(1, 0)
+	fmt.Printf("AdmitAt(%v, %s) will block.\n", ld0, t1.Format("0.0"))
+	ctxToCancel, cancel := context.WithCancel(ctx)
+	errCh := make(chan error)
+	go func() { errCh <- c.AdmitAt(ctxToCancel, ld0, t1) }()
+	waitForState(c, 0, 1)
+	fmt.Println(c)
+	fmt.Println()
+	fmt.Println("Cancel the request at", ld0, "so it is no longer blocked.")
+	cancel()
+	<-errCh
+	fmt.Println("Observe that the request is no longer blocked.")
+	fmt.Println(c)
+	// Output:
+	// The controller begins at the lowest level.
+	// ---|  h   |  d   |  l   |
+	// 127|  0.00|  0.00|  0.00|
+	// ...
+	// 0  |  0.00|  0.00|➡ 0.00|
+	// int: 0; ad: 0; bl: 0; rej: 0
+	//
+	// Three requests come in and succeed in the current interval.
+	// AdmitAt(d:127, 0.0) = <nil>.
+	// AdmitAt(d:0, 0.0) = <nil>.
+	// AdmitAt(d:1, 0.0) = <nil>.
+	// ---|  h   |  d   |  l   |
+	// 127|  0.00|  1.00|  0.00|
+	// ...
+	// 1  |  0.00|  1.00|  0.00|
+	// 0  |  0.00|  1.00|➡ 0.00|
+	// int: 1; ad: 3; bl: 0; rej: 0
+	//
+	// The overload signal becomes true and time advances to 0.1.
+	// AdmitAt(d:0, 0.0) will block.
+	// ---|  h   |  d   |  l   |
+	// 127|  0.00|  0.00|  0.00|
+	// ...
+	// 1  |  0.00|➡ 0.00|  0.00|
+	// 0  |  0.00|  1.00|  0.00|
+	// int: 2; ad: 0; bl: 1; rej: 0
+	//
+	// Cancel the request at d:0 so it is no longer blocked.
+	// Observe that the request is no longer blocked.
+	// ---|  h   |  d   |  l   |
+	// 127|  0.00|  0.00|  0.00|
+	// ...
+	// 1  |  0.00|➡ 0.00|  0.00|
+	// 0  |  0.00|  0.00|  0.00|
+	// int: 2; ad: 0; bl: 0; rej: 0
+}
+
+func ExampleController_waiting() {
+	var overloaded atomic.Value
+	overloaded.Store(false)
+	cfg := testConfig
+	cfg.MaxReqsPerInterval = 1000000
+	cfg.OverloadSignal = func(qos.Level) (bool, qos.Level) {
+		return overloaded.Load().(bool), maxLevel
+	}
+	ctx := context.Background()
+	c := NewController(ctx, nil, cfg)
+	const reqsToAdd = 1000
+	const reqsPerLevel = reqsToAdd / 10
+	fmt.Println("Admit", reqsToAdd, "requests uniformly between", ld1, "and", ld10, " at t1.")
+	for l := ld1; !ld10.Less(l); l = l.Inc() {
+		for i := 0; i < reqsPerLevel; i++ {
+			if err := c.AdmitAt(ctx, l, t1); err != nil {
+				fmt.Println("Got an error", err)
+			}
+		}
+	}
+	fmt.Println("After adding all of the requests the controller state looks like this:")
+	fmt.Println(c)
+	fmt.Println()
+	fmt.Println("Set the overload signal to true and Admit a request at t2, leading to a tick.")
+	overloaded.Store(true)
+	fmt.Printf("AdmitAt(%v, t%d) = %v.\n", ld127, t0.Unix(), c.AdmitAt(ctx, ld127, t0))
+	if err := c.AdmitAt(ctx, ld127, t2); err != nil {
+		fmt.Println("Got an error", err)
+	}
+	fmt.Println("Notice that the admission level has risen to", c.AdmissionLevel())
+	fmt.Println(c)
+	fmt.Println()
+	fmt.Println("Attempt to admit", reqsToAdd, "requests uniformly between", ld1, "and", ld10, "at t2.")
+	fmt.Println("901 should be admitted and 100 should be blocked.")
+	for l := ld1; !ld10.Less(l); l = l.Inc() {
+		for i := 0; i < reqsPerLevel; i++ {
+			if !l.Less(c.AdmissionLevel()) {
+				c.AdmitAt(ctx, l, t2)
+			} else {
+				go c.AdmitAt(ctx, l, t2)
+			}
+		}
+	}
+	waitForState(c, 901, 100)
+	fmt.Println(c)
+	fmt.Println()
+	fmt.Println("Set the overload signal to false.")
+	overloaded.Store(false)
+	fmt.Println("Admit a request at t3 leading to a tick moves the admission level down to def:1.")
+	c.AdmitAt(ctx, ld127, t3)
+	waitForState(c, 101, 0)
+	fmt.Println(c)
+	fmt.Println("Also in t3 add more requests than can fit in the waitQueue (1000).")
+	fmt.Println("This is done by adding", reqsPerLevel-1, "requests to", ld0,
+		"and", reqsPerLevel, "uniformly from", ll10, "to", ll1, ".")
+	fmt.Println("This will lead to requests at", ll1, "being rejected.")
+	// NB: The requests are added in decreasing order to ensure that the rejection
+	// level rises deterministically.
+	expectedNumBlocked := int(c.numBlocked())
+	errCh := make(chan error)
+	addAtLevel := func(n int, p qos.Level) {
+		for i := 0; i < n; i++ {
+			go func() { errCh <- c.AdmitAt(ctx, p, t3) }()
+			expectedNumBlocked++
+		}
+		if expectedNumBlocked >= int(cfg.MaxBlocked) {
+			expectedNumBlocked -= n
+		}
+		waitForState(c, 0, expectedNumBlocked)
+	}
+	addAtLevel(reqsPerLevel-1, ld0)
+	for l := ll10; ll0.Less(l); l = l.Dec() {
+		addAtLevel(reqsPerLevel, l)
+	}
+	for i := 0; i < 100; i++ {
+		if err := <-errCh; err != ErrRejected {
+			fmt.Println("Got an unexpected", err)
+		}
+	}
+	fmt.Println(c)
+	// Output:
+	// Admit 1000 requests uniformly between d:1 and d:10  at t1.
+	// After adding all of the requests the controller state looks like this:
+	// ---|  h   |  d   |  l   |
+	// 127|  0.00|  0.00|  0.00|
+	// ...
+	// 10 |  0.00|  100 |  0.00|
+	// 9  |  0.00|  100 |  0.00|
+	// 8  |  0.00|  100 |  0.00|
+	// 7  |  0.00|  100 |  0.00|
+	// 6  |  0.00|  100 |  0.00|
+	// 5  |  0.00|  100 |  0.00|
+	// 4  |  0.00|  100 |  0.00|
+	// 3  |  0.00|  100 |  0.00|
+	// 2  |  0.00|  100 |  0.00|
+	// 1  |  0.00|  100 |  0.00|
+	// 0  |  0.00|  0.00|➡ 0.00|
+	// int: 1; ad: 1000; bl: 0; rej: 0
+	//
+	// Set the overload signal to true and Admit a request at t2, leading to a tick.
+	// AdmitAt(d:127, t0) = <nil>.
+	// Notice that the admission level has risen to d:2
+	// ---|  h   |  d   |  l   |
+	// 127|  0.00|  1.00|  0.00|
+	// ...
+	// 2  |  0.00|➡ 0.00|  0.00|
+	// ...
+	// 0  |  0.00|  0.00|  0.00|
+	// int: 2; ad: 1; bl: 0; rej: 0
+	//
+	// Attempt to admit 1000 requests uniformly between d:1 and d:10 at t2.
+	// 901 should be admitted and 100 should be blocked.
+	// ---|  h   |  d   |  l   |
+	// 127|  0.00|  1.00|  0.00|
+	// ...
+	// 10 |  0.00|  100 |  0.00|
+	// 9  |  0.00|  100 |  0.00|
+	// 8  |  0.00|  100 |  0.00|
+	// 7  |  0.00|  100 |  0.00|
+	// 6  |  0.00|  100 |  0.00|
+	// 5  |  0.00|  100 |  0.00|
+	// 4  |  0.00|  100 |  0.00|
+	// 3  |  0.00|  100 |  0.00|
+	// 2  |  0.00|➡ 100 |  0.00|
+	// 1  |  0.00|  100 |  0.00|
+	// 0  |  0.00|  0.00|  0.00|
+	// int: 2; ad: 901; bl: 100; rej: 0
+	//
+	// Set the overload signal to false.
+	// Admit a request at t3 leading to a tick moves the admission level down to def:1.
+	// ---|  h   |  d   |  l   |
+	// 127|  0.00|  1.00|  0.00|
+	// ...
+	// 1  |  0.00|➡ 100 |  0.00|
+	// 0  |  0.00|  0.00|  0.00|
+	// int: 3; ad: 101; bl: 0; rej: 0
+	// Also in t3 add more requests than can fit in the waitQueue (1000).
+	// This is done by adding 99 requests to d:0 and 100 uniformly from l:10 to l:1 .
+	// This will lead to requests at l:1 being rejected.
+	// ---|  h   |  d   |  l   |
+	// 127|  0.00|  1.00|  0.00|
+	// ...
+	// 10 |  0.00|  0.00|  100 |
+	// 9  |  0.00|  0.00|  100 |
+	// 8  |  0.00|  0.00|  100 |
+	// 7  |  0.00|  0.00|  100 |
+	// 6  |  0.00|  0.00|  100 |
+	// 5  |  0.00|  0.00|  100 |
+	// 4  |  0.00|  0.00|  100 |
+	// 3  |  0.00|  0.00|  100 |
+	// 2  |  0.00|  0.00|  100 |
+	// 1  |  0.00|➡ 100 |⇨ 100 |
+	// 0  |  0.00|  99.0|  0.00|
+	// int: 3; ad: 101; bl: 999; rej: 100
+}
+
+func waitForNotAdmissionLevel(c *Controller, l qos.Level) {
+	for c.AdmissionLevel() == l {
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func waitForState(c *Controller, expNumAdmitted, expNumBlocked int) {
+	for {
+		curNumReqs := c.numAdmitted()
+		curNumBlocked := c.numBlocked()
+		if (expNumAdmitted <= 0 || curNumReqs >= expNumAdmitted) &&
+			(expNumBlocked <= 0 || curNumBlocked >= expNumBlocked) {
+			return
+		}
+		if log.V(1) {
+			log.InfofDepth(context.TODO(), 1, "waiting for numAdmitted=%d (cur %d) and numBlocked=%d (cur %d)",
+				expNumAdmitted, curNumReqs, expNumBlocked, curNumBlocked)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func (c *Controller) numAdmitted() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return int(atomic.LoadInt64(&c.mu.numAdmitted))
+}
+
+func (c *Controller) numBlocked() (blocked int) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for cl := 0; cl < qos.NumClasses; cl++ {
+		for s := 0; s < qos.NumShards; s++ {
+			blocked += int(c.mu.wq[cl][s].len())
+		}
+	}
+	return blocked
+}

--- a/pkg/qos/controller/metrics.go
+++ b/pkg/qos/controller/metrics.go
@@ -1,0 +1,83 @@
+package controller
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+type Metrics struct {
+	AdmissionLevel *metric.Gauge
+	RejectionLevel *metric.Gauge
+	CurNumBlocked  *metric.Gauge
+	NumBlocked     *metric.Counter
+	NumUnblocked   *metric.Counter
+	NumTicks       *metric.Counter
+	Inc            *metric.Counter
+	Dec            *metric.Counter
+}
+
+func makeMeta(md metric.Metadata, name string) metric.Metadata {
+	md.Name = name + "." + md.Name
+	return md
+}
+
+func makeMetrics(name string) Metrics {
+	return Metrics{
+		AdmissionLevel: metric.NewGauge(makeMeta(metaAdmissionLevel, name)),
+		RejectionLevel: metric.NewGauge(makeMeta(metaRejectionLevel, name)),
+		CurNumBlocked:  metric.NewGauge(makeMeta(metaCurNumBlocked, name)),
+		NumBlocked:     metric.NewCounter(makeMeta(metaNumBlocked, name)),
+		NumUnblocked:   metric.NewCounter(makeMeta(metaNumUnblocked, name)),
+		NumTicks:       metric.NewCounter(makeMeta(metaNumTicks, name)),
+		Inc:            metric.NewCounter(makeMeta(metaNumInc, name)),
+		Dec:            metric.NewCounter(makeMeta(metaNumDec, name)),
+	}
+}
+
+var (
+	metaAdmissionLevel = metric.Metadata{
+		Name:        "admission.level",
+		Help:        "Current admission level",
+		Unit:        metric.Unit_COUNT,
+		Measurement: "admission level",
+	}
+	metaRejectionLevel = metric.Metadata{
+		Name:        "rejection.level",
+		Help:        "Current rejection level",
+		Unit:        metric.Unit_COUNT,
+		Measurement: "rejection level",
+	}
+	metaNumTicks = metric.Metadata{
+		Name:        "admission.ticks",
+		Help:        "Number of ticks",
+		Unit:        metric.Unit_COUNT,
+		Measurement: "ticks",
+	}
+	metaNumDec = metric.Metadata{
+		Name:        "admission.decrease",
+		Help:        "Number of times the tick has decreased the level",
+		Unit:        metric.Unit_COUNT,
+		Measurement: "ticks",
+	}
+	metaNumInc = metric.Metadata{
+		Name:        "admission.increase",
+		Help:        "Number of times the tick has increase the level",
+		Unit:        metric.Unit_COUNT,
+		Measurement: "ticks",
+	}
+	metaCurNumBlocked = metric.Metadata{
+		Name:        "admission.cur_num_blocked",
+		Help:        "Gauge of currently blocked requests",
+		Unit:        metric.Unit_COUNT,
+		Measurement: "requests",
+	}
+	metaNumBlocked = metric.Metadata{
+		Name:        "admission.num_blocked",
+		Help:        "Counter of blocked requests",
+		Unit:        metric.Unit_COUNT,
+		Measurement: "requests",
+	}
+	metaNumUnblocked = metric.Metadata{
+		Name:        "admission.num_unblocked",
+		Help:        "Counter of unblocked requests",
+		Unit:        metric.Unit_COUNT,
+		Measurement: "requests",
+	}
+)

--- a/pkg/qos/doc.go
+++ b/pkg/qos/doc.go
@@ -1,0 +1,23 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package qos defines quality of service, a best-effort mechanism to prioritize
+// traffic in cockroachdb.
+//
+// The quality of service Level is a request annotation which propagates through
+// the system generally via a context mechanism and gRPC middleware. Components
+// consult qos levels as part of providing mechanisms to mitigate overload and
+// protect higher Class traffic from the load due to lower Class traffic.
+// Class represents client intention to prioritize or deprioritize a request
+// relative to other traffic. Shard is a uniform property of the client
+// connection from which a Level originates. This two-level space cruciallly
+// allows servers experiencing overload to agree on which requests of a given
+// class to throttle without the need for explicit coordination.
+package qos

--- a/pkg/qos/level.go
+++ b/pkg/qos/level.go
@@ -47,6 +47,15 @@ func (l Class) IsValid() bool {
 	return l < NumClasses
 }
 
+// String returns a shorthand string for the Class if it is valid or a decimal
+// integer representation if it is not.
+func (c Class) String() string {
+	if c.IsValid() {
+		return classStrings[c]
+	}
+	return strconv.Itoa(int(c))
+}
+
 // Shard indicates a shard within a Class.
 // A shard subdivides a class generally based on a constant property of the
 // client connection from which the corresponding request originates. Shard
@@ -273,4 +282,28 @@ func levelToText(l Level) [textLen]byte {
 		panic(fmt.Errorf("expected to encode %d bytes, got %d", n, len(out)))
 	}
 	return out
+}
+
+var (
+	classes = [NumClasses]Class{ClassHigh, ClassDefault, ClassLow}
+	shards  = func() (shards [NumShards]Shard) {
+		for i := 0; i < NumShards; i++ {
+			shards[NumShards-1-i] = Shard(i)
+		}
+		return shards
+	}()
+)
+
+// Classes returns an array of classes ordered from highest to lowest.
+// This function exists to ease code which iterates over classes in descending
+// order.
+func Classes() [NumClasses]Class {
+	return classes
+}
+
+// Shards return an array of Shard values ordered from highest (NumShards-1) to
+// lowest (0). This function exists to ease code which iterates over classes in
+// descending order.
+func Shards() [NumShards]Shard {
+	return shards
 }

--- a/pkg/qos/level.go
+++ b/pkg/qos/level.go
@@ -15,7 +15,11 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
+	"reflect"
 	"strconv"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
 // Class indicates traffic of a certain quality.
@@ -106,6 +110,17 @@ func Decode(p uint32) Level {
 	}
 }
 
+// DecodeString decodes a priority from a string.
+// The string should be a 4 character hex encoded value as returned from
+// EncodeString.
+func DecodeString(s string) (Level, error) {
+	var l Level
+	if err := l.UnmarshalText(encoding.UnsafeConvertStringToBytes(s)); err != nil {
+		return Level{}, err
+	}
+	return l, nil
+}
+
 // IsValid return true if p has a valid value.
 func (l Level) IsValid() bool {
 	return l.Class.IsValid() && l.Shard.IsValid()
@@ -145,8 +160,20 @@ func (l Level) Less(other Level) bool {
 
 // Encode encodes a priority to a uint32.
 // Encoded priorities can be compared using normal comparison operators.
+// Encode will panic if l is not valid.
 func (l Level) Encode() uint32 {
 	return uint32(encodeClass(l.Class))<<8 | uint32(encodeShard(l.Shard))
+}
+
+// EncodeString encodes a priority to a string.
+// The returned string will be a 4 character lower-case hex encoded value.
+// String encoded priorities can be compared using normal comparison operators.
+// EncodeString will panic if l is not valid.
+func (l Level) EncodeString() string {
+	if !l.IsValid() {
+		panic(fmt.Errorf("cannot encode invalid Level %v", l))
+	}
+	return marshaledString[l.Class][l.Shard]
 }
 
 // String returns a string formatted as Class:Shard where Shard is always an
@@ -218,6 +245,7 @@ var classStrings = [NumClasses]string{
 }
 
 var marshaledText [NumClasses][NumShards][textLen]byte
+var marshaledString [NumClasses][NumShards]string
 
 // textLen is the length of a hex-encoded Level.
 const textLen = 4 // 2 * 2 bytes = 4
@@ -225,7 +253,13 @@ const textLen = 4 // 2 * 2 bytes = 4
 func init() {
 	for c := Class(0); c < NumClasses; c++ {
 		for s := Shard(0); s < NumShards; s++ {
-			marshaledText[c][s] = levelToText(Level{c, s})
+			text := levelToText(Level{c, s})
+			marshaledText[c][s] = text
+			var str string
+			strHdr := (*reflect.StringHeader)(unsafe.Pointer(&str))
+			strHdr.Data = uintptr(unsafe.Pointer(&text[0]))
+			strHdr.Len = len(text)
+			marshaledString[c][s] = str
 		}
 	}
 }

--- a/pkg/qos/level.go
+++ b/pkg/qos/level.go
@@ -1,0 +1,242 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package qos
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"strconv"
+)
+
+// Class indicates traffic of a certain quality.
+// The values of Class are explicitly defined as ClassHigh, ClassDefault, and
+// ClassLow. Class represents a client intention to prioritize this request
+// relative to requests of different Classes. Each Class is broken into NumShard
+// Shards which enables the system to make finer granularity admission control
+// decisions than if it could only rely uniformly on Class.
+type Class uint8
+
+const (
+	// ClassHigh is the highest quality of service class.
+	ClassHigh Class = NumClasses - 1 - iota
+	// ClassDefault is the default quality of service class.
+	ClassDefault
+	// ClassLow is the lowest quality of service class.
+	ClassLow
+
+	// NumClasses is the total number of levels.
+	NumClasses = iota // 3
+)
+
+// IsValid is true if Class is in [0, NumClasses).
+func (l Class) IsValid() bool {
+	return l < NumClasses
+}
+
+// Shard indicates a shard within a Class.
+// A shard subdivides a class generally based on a constant property of the
+// client connection from which the corresponding request originates. Shard
+// provides the system with a finer granularity for admission control decisions.
+// Shard helps the distributed system to mitigate the challenges due to
+// "multiple overload" whereby during the processing of a single client request
+// may need to visit more than downstream server which is overloaded. If traffic
+// of a given Class were uniformly affected then even if each individual server
+// were to only backpressure a small fraction of incident requests, a large
+// fraction could observe some backpressure. Using a Shard in conjunction with a
+// Class allows servers to agree on which traffic of a Class should experience
+// backpressure without explicit coordination.
+type Shard uint8
+
+// NumShards is the total number of logical shards.
+// The current value is arbitrary and could change over time. Given a small
+// number of classes, having a large number of shards gives the system the
+// most granularity on which to make qos decisions.
+const NumShards = 128
+
+// IsValid is true if Shard is in [0, NumShards).
+func (s Shard) IsValid() bool {
+	return s < NumShards
+}
+
+// Level represents a quality of service level.
+//
+// The qos space is an ordered tuple of Class and Shard where Class is the
+// higher order field (i.e. if a Level has a larger Class value than another
+// it is larger). In general, Class represents user intention of
+//
+// The quality of service space is broken up into explicit classes which are
+// subdivided into shards. This tuple space allows nodes to make indepedent
+// admission decisions which will cooperate to backpressure traffic in an
+// orderly manner without explicit coordination.
+//
+// While its fields are uint8, the values for a valid Class are contained in
+// [0, NumClasses) and the values for a valid Shard are contained in
+// [0, NumShards). A Level which contains a Class or Shard outside of that
+// range is not valid. Levels which are not valid will cause a panic during
+// encoding. Encoded values however are spread over the uint8 space to allow
+// for future versions to use different numbers of classes and shards in a
+// forward and backward compatible way.
+type Level struct {
+
+	// Class indicates the level associated with this priority.
+	// For a valid Level its value lies in [0, NumClasses).
+	Class Class
+
+	// Shard indicates the priority shard within this level.
+	// For a valid Level its value lies in [0, NumShards).
+	Shard Shard
+}
+
+// Decode decodes a priority from a uint32.
+// The high 16 bits are ignored.
+func Decode(p uint32) Level {
+	return Level{
+		Class: decodeClass(p),
+		Shard: decodeShard(p),
+	}
+}
+
+// IsValid return true if p has a valid value.
+func (l Level) IsValid() bool {
+	return l.Class.IsValid() && l.Shard.IsValid()
+}
+
+// Dec returns the next lower priority value unless p is the minimum value
+// in which case p is returned.
+func (l Level) Dec() Level {
+	if l.Shard > 0 {
+		l.Shard--
+	} else if l.Class > 0 {
+		l.Class--
+		l.Shard = NumShards - 1
+	}
+	return l
+}
+
+// Inc returns the next higher priority value unless p is the maximum value
+// in which case p is returned.
+func (l Level) Inc() Level {
+	if l.Shard < NumShards-1 {
+		l.Shard++
+	} else if l.Class < NumClasses-1 {
+		l.Class++
+		l.Shard = 0
+	}
+	return l
+}
+
+// Less returns true if p is less than other.
+func (l Level) Less(other Level) bool {
+	if l.Class == other.Class {
+		return l.Shard < other.Shard
+	}
+	return l.Class < other.Class
+}
+
+// Encode encodes a priority to a uint32.
+// Encoded priorities can be compared using normal comparison operators.
+func (l Level) Encode() uint32 {
+	return uint32(encodeClass(l.Class))<<8 | uint32(encodeShard(l.Shard))
+}
+
+// String returns a string formatted as Class:Shard where Shard is always an
+// integer and Class uses a shorthand string if it is valid or an intger if not.
+func (l Level) String() string {
+	if l.Class >= NumClasses {
+		return strconv.Itoa(int(l.Class)) + ":" + strconv.Itoa(int(l.Shard))
+	}
+	return classStrings[l.Class] + ":" + strconv.Itoa(int(l.Shard))
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (l Level) MarshalText() ([]byte, error) {
+	if !l.IsValid() {
+		return nil, fmt.Errorf("cannot marshal invalid Level (%d, %d) to text", l.Class, l.Shard)
+	}
+	return marshaledText[l.Class][l.Shard][:], nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (l *Level) UnmarshalText(data []byte) error {
+	if len(data) != textLen {
+		return fmt.Errorf("invalid data length %d, expected %d", len(data), textLen)
+	}
+	var decoded [2]byte
+	if _, err := hex.Decode(decoded[:], data); err != nil {
+		return err
+	}
+	*l = Decode(uint32(binary.BigEndian.Uint16(decoded[:])))
+	return nil
+}
+
+// classStep and shardStep are used in encoding a decoding.
+// When encoded the Class and Shard values are spread over the space of uint8
+// in order to accommodate later changes to NumClasses or NumShards.
+const (
+	classStep = math.MaxUint8 / (NumClasses - 1)
+	shardStep = math.MaxUint8 / (NumShards - 1)
+)
+
+func encodeClass(l Class) uint8 {
+	if !l.IsValid() {
+		panic(fmt.Errorf("cannot encode invalid level %d", l))
+	}
+	const minEncodedClass = math.MaxUint8 % classStep
+	return minEncodedClass + uint8(l*classStep)
+}
+
+func encodeShard(s Shard) uint8 {
+	if !s.IsValid() {
+		panic(fmt.Errorf("cannot encode invalid shard %d", s))
+	}
+	const minEncodedShard = math.MaxUint8 % shardStep
+	return minEncodedShard + uint8(s*shardStep)
+}
+
+func decodeShard(e uint32) Shard {
+	return Shard(e) / shardStep
+}
+
+func decodeClass(e uint32) Class {
+	return Class(e>>8) / classStep
+}
+
+var classStrings = [NumClasses]string{
+	ClassHigh:    "h",
+	ClassDefault: "d",
+	ClassLow:     "l",
+}
+
+var marshaledText [NumClasses][NumShards][textLen]byte
+
+// textLen is the length of a hex-encoded Level.
+const textLen = 4 // 2 * 2 bytes = 4
+
+func init() {
+	for c := Class(0); c < NumClasses; c++ {
+		for s := Shard(0); s < NumShards; s++ {
+			marshaledText[c][s] = levelToText(Level{c, s})
+		}
+	}
+}
+
+func levelToText(l Level) [textLen]byte {
+	var data [2]byte
+	var out [4]byte
+	data[0] = encodeClass(l.Class)
+	data[1] = encodeShard(l.Shard)
+	if n := hex.Encode(out[:], data[:]); n != len(out) {
+		panic(fmt.Errorf("expected to encode %d bytes, got %d", n, len(out)))
+	}
+	return out
+}

--- a/pkg/qos/level_test.go
+++ b/pkg/qos/level_test.go
@@ -1,0 +1,288 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package qos
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLevelBuckets(t *testing.T) {
+	for _, tc := range []struct {
+		l       Level
+		encoded uint32
+		str     string
+		valid   bool
+	}{
+		{
+			Level{ClassHigh, 127},
+			0x0000FFFF,
+			"h:127",
+			true,
+		},
+		{
+			Level{ClassHigh, 126},
+			0x0000FFFD,
+			"h:126",
+			true,
+		},
+		{
+			Level{ClassHigh, 1},
+			0x0000FF03,
+			"h:1",
+			true,
+		},
+		{
+			Level{ClassHigh, 0},
+			0x0000FF01,
+			"h:0",
+			true,
+		},
+		{
+			Level{ClassDefault, 127},
+			0x000080FF,
+			"d:127",
+			true,
+		},
+		{
+			Level{ClassLow, 125},
+			0x000001FB,
+			"l:125",
+			true,
+		},
+		{
+			Level{ClassHigh, 128},
+			0x0000FFFF,
+			"h:128",
+			false,
+		},
+		{
+			Level{17, 2},
+			0x0000FF05,
+			"17:2",
+			false,
+		},
+	} {
+		t.Run(fmt.Sprintf("%s->%x", tc.l, tc.encoded), func(t *testing.T) {
+			assert.Equal(t, tc.valid, tc.l.IsValid())
+			assert.Equal(t, tc.str, tc.l.String())
+			l := tc.l
+			if !tc.l.IsValid() {
+				l = clampToValid(l)
+			}
+			assert.Equal(t, tc.encoded, l.Encode())
+			assert.Equal(t, l, Decode(tc.encoded))
+		})
+	}
+}
+
+func clampToValid(l Level) Level {
+	if l.Class >= NumClasses {
+		l.Class = NumClasses - 1
+	}
+	if l.Shard >= NumShards {
+		l.Shard = NumShards - 1
+	}
+	return l
+}
+
+func TestIncDec(t *testing.T) {
+	levels := make([]Level, 0, NumClasses*NumShards)
+	for c := Class(0); c < NumClasses; c++ {
+		for s := Shard(0); s < NumShards; s++ {
+			levels = append(levels, Level{Class: c, Shard: s})
+		}
+	}
+	randIncDecTest := func() {
+		start := rand.Intn(len(levels))
+		var incs, decs int
+		l := levels[start]
+		const N = 500
+		for i := 0; i < N; i++ {
+			var next Level
+			if inc := rand.Intn(2) == 1; inc {
+				if next = l.Inc(); next != l {
+					incs++
+				}
+			} else {
+				if next = l.Dec(); next != l {
+					decs++
+				}
+			}
+			l = next
+			end := start + incs - decs
+			assert.Equal(t, levels[end], l)
+		}
+	}
+	const trials = 100
+	for i := 0; i < trials; i++ {
+		randIncDecTest()
+	}
+}
+
+// TestOrdering ensures that Level provides a total ordering both using the
+// Less method as well as comparing values creates with Encode.
+func TestOrdering(t *testing.T) {
+	// Each test case is provided as a slice of Levels in sorted order.
+	// The test ensure that comparisons are valid both using the Less method
+	// as well as using the numerical comparison of encoded values.
+	cases := [][]Level{
+		{
+			{ClassDefault, 127},
+			{ClassHigh, 2},
+			{ClassHigh, 126},
+			{ClassHigh, 127},
+		},
+		{
+			{ClassLow, 0},
+			{ClassLow, 127},
+			{ClassDefault, 127},
+			{ClassHigh, 127},
+		},
+	}
+	// shuffled returns a shuffled copy of l.
+	shuffled := func(l []Level) []Level {
+		l = append([]Level{}, l...)
+		rand.Shuffle(len(l), func(i, j int) {
+			l[i], l[j] = l[j], l[i]
+		})
+		return l
+	}
+	lessLess := func(a, b Level) bool {
+		return a.Less(b)
+	}
+	lessEncoded := func(a, b Level) bool {
+		return a.Encode() < b.Encode()
+	}
+	test := func(sorted []Level, less func(a, b Level) bool) func(t *testing.T) {
+		return func(t *testing.T) {
+			l := shuffled(sorted)
+			sort.Slice(l, func(i, j int) bool {
+				return less(l[i], l[j])
+			})
+			assert.EqualValues(t, sorted, l)
+		}
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%v/Less", tc), test(tc, lessLess))
+		t.Run(fmt.Sprintf("%v/Encoded", tc), test(tc, lessEncoded))
+	}
+}
+
+// TestDecode tests that various encoded values decode as expected.
+func TestDecode(t *testing.T) {
+	for _, tc := range []struct {
+		encoded uint32
+		level   Level
+	}{
+		{0xFF00, Level{ClassHigh, 0}},
+		{0xFF01, Level{ClassHigh, 0}},
+		{0xFF02, Level{ClassHigh, 1}},
+		{0x1234FF02, Level{ClassHigh, 1}},
+		{0xFFFFFF02, Level{ClassHigh, 1}},
+		{0xFFFFFFFE, Level{ClassHigh, 127}},
+		{0xFFFFFFFD, Level{ClassHigh, 126}},
+		{0xFFFD, Level{ClassHigh, 126}},
+	} {
+		assert.Equal(t, tc.level, Decode(tc.encoded))
+	}
+}
+
+// TestInvalidEncodePanics ensures that encoding an invalid Level leads to a
+// panic.
+func TestInvalidEncodePanics(t *testing.T) {
+	for _, tc := range []Level{
+		{NumClasses, 0},
+		{NumClasses + 1, 0},
+		{math.MaxUint8, math.MaxUint8},
+		{0, NumShards},
+		{0, NumShards + 1},
+		{0, math.MaxUint8},
+	} {
+		assert.Panics(t, func() {
+			tc.Encode()
+		}, "(%d, %d)", tc.Class, tc.Shard)
+	}
+}
+
+func TestUnmarshalText(t *testing.T) {
+	for _, tc := range []struct {
+		in  []byte
+		out Level
+		err string
+	}{
+		{
+			in:  []byte("ff05"),
+			out: Level{ClassHigh, 2},
+		},
+		{
+			in:  []byte(""),
+			err: "invalid data length 0, expected 4",
+		},
+		{
+			in:  []byte("000z"),
+			err: "encoding/hex: invalid byte:",
+		},
+		{
+			in:  []byte("0000"),
+			out: Level{ClassLow, 0},
+		},
+	} {
+		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
+			var l Level
+			err := l.UnmarshalText(tc.in)
+			if tc.err != "" {
+				if assert.Error(t, err) {
+					assert.Regexp(t, tc.err, err.Error())
+				}
+			} else {
+				assert.Equal(t, tc.out, l)
+			}
+		})
+	}
+}
+
+func TestMarshalText(t *testing.T) {
+	for _, tc := range []struct {
+		l   Level
+		out []byte
+		err string
+	}{
+		{
+			l:   Level{ClassHigh, 2},
+			out: []byte("ff05"),
+		},
+		{
+			l:   Level{4, 2},
+			err: "cannot marshal invalid Level",
+		},
+		{
+			l:   Level{ClassLow, math.MaxUint8},
+			err: "cannot marshal invalid Level",
+		},
+	} {
+		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
+			out, err := tc.l.MarshalText()
+			if tc.err != "" {
+				if assert.Error(t, err) {
+					assert.Regexp(t, tc.err, err.Error())
+				}
+			} else {
+				assert.Equal(t, tc.out, out)
+			}
+		})
+	}
+}

--- a/pkg/qos/level_test.go
+++ b/pkg/qos/level_test.go
@@ -11,6 +11,7 @@
 package qos
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -285,4 +286,16 @@ func TestMarshalText(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestContext(t *testing.T) {
+	ctx := context.Background()
+	got, ok := LevelFromContext(ctx)
+	assert.Zero(t, got)
+	assert.False(t, ok)
+	l := Level{ClassHigh, 12}
+	ctx = ContextWithLevel(ctx, l)
+	got, ok = LevelFromContext(ctx)
+	assert.Equal(t, l, got)
+	assert.True(t, ok)
 }

--- a/pkg/qos/level_test.go
+++ b/pkg/qos/level_test.go
@@ -216,10 +216,13 @@ func TestInvalidEncodePanics(t *testing.T) {
 		assert.Panics(t, func() {
 			tc.Encode()
 		}, "(%d, %d)", tc.Class, tc.Shard)
+		assert.Panics(t, func() {
+			tc.EncodeString()
+		}, "(%d, %d)", tc.Class, tc.Shard)
 	}
 }
 
-func TestUnmarshalText(t *testing.T) {
+func TestDecodeStringAndUnmarshalText(t *testing.T) {
 	for _, tc := range []struct {
 		in  []byte
 		out Level
@@ -234,6 +237,10 @@ func TestUnmarshalText(t *testing.T) {
 			err: "invalid data length 0, expected 4",
 		},
 		{
+			in:  nil,
+			err: "invalid data length 0, expected 4",
+		},
+		{
 			in:  []byte("000z"),
 			err: "encoding/hex: invalid byte:",
 		},
@@ -242,7 +249,17 @@ func TestUnmarshalText(t *testing.T) {
 			out: Level{ClassLow, 0},
 		},
 	} {
-		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%v/DecodeString", tc), func(t *testing.T) {
+			l, err := DecodeString(string(tc.in))
+			if tc.err != "" {
+				if assert.Error(t, err) {
+					assert.Regexp(t, tc.err, err.Error())
+				}
+			} else {
+				assert.Equal(t, tc.out, l)
+			}
+		})
+		t.Run(fmt.Sprintf("%v/UnmarshalText", tc), func(t *testing.T) {
 			var l Level
 			err := l.UnmarshalText(tc.in)
 			if tc.err != "" {
@@ -283,6 +300,7 @@ func TestMarshalText(t *testing.T) {
 				}
 			} else {
 				assert.Equal(t, tc.out, out)
+				assert.Equal(t, string(tc.out), tc.l.EncodeString())
 			}
 		})
 	}

--- a/pkg/rpc/qos.go
+++ b/pkg/rpc/qos.go
@@ -1,0 +1,76 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rpc
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/qos"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func qosClientInterceptor(
+	prevUnaryInterceptor grpc.UnaryClientInterceptor,
+) grpc.UnaryClientInterceptor {
+	return func(
+		goCtx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+	) error {
+		// Add a qos level header if the goCtx contains a qos level.
+		if l, haveLevel := qos.LevelFromContext(goCtx); haveLevel {
+			goCtx = metadata.AppendToOutgoingContext(goCtx, clientQosLevelKey, l.EncodeString())
+		}
+		// Chain the previous interceptor if there is one.
+		if prevUnaryInterceptor != nil {
+			return prevUnaryInterceptor(goCtx, method, req, reply, cc, invoker, opts...)
+		}
+		return invoker(goCtx, method, req, reply, cc, opts...)
+	}
+}
+
+func qosServerInterceptor(
+	prevUnaryInterceptor grpc.UnaryServerInterceptor,
+) grpc.UnaryServerInterceptor {
+	warnTooManyEvery := log.Every(time.Second)
+	errMalformedQosLevelEvery := log.Every(time.Second)
+	return func(
+		goCtx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		if md, ok := metadata.FromIncomingContext(goCtx); ok {
+			if v := md.Get(clientQosLevelKey); len(v) > 0 {
+				// We don't expect more than one item; gRPC does not copy metadata
+				// from one incoming RPC to an outgoing RPC, so there should be a
+				// single qos level in the context put there by the interceptor on the
+				// client before calling this RPC. Nevertheless, having two is only
+				// logged and is not treated as an error.
+				if len(v) > 1 && warnTooManyEvery.ShouldLog() {
+					log.Warningf(goCtx, "unexpected multiple qos levels in client metadata: %s", v)
+				}
+				// If a qos level header exists but is malformed it is ignored but a
+				// message is logged with the corresponding error.
+				// TODO(ajwerner): consider if this behavior should be less lenient for
+				// malformed headers.
+				if l, err := qos.DecodeString(v[0]); err == nil {
+					goCtx = qos.ContextWithLevel(goCtx, l)
+				} else if errMalformedQosLevelEvery.ShouldLog() {
+					log.Errorf(goCtx, "malformed qos level %s header: %v", clientQosLevelKey, err)
+				}
+			}
+		}
+		if prevUnaryInterceptor != nil {
+			return prevUnaryInterceptor(goCtx, req, info, handler)
+		}
+		return handler(goCtx, req)
+	}
+}

--- a/pkg/rpc/qos_test.go
+++ b/pkg/rpc/qos_test.go
@@ -1,0 +1,196 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/qos"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+type internalServerFunc func(
+	context.Context, *roachpb.BatchRequest,
+) (*roachpb.BatchResponse, error)
+
+func (f internalServerFunc) Batch(
+	ctx context.Context, ba *roachpb.BatchRequest,
+) (*roachpb.BatchResponse, error) {
+	return f(ctx, ba)
+}
+
+func (f internalServerFunc) RangeFeed(
+	_ *roachpb.RangeFeedRequest, _ roachpb.Internal_RangeFeedServer,
+) error {
+	panic("unimplemented")
+}
+
+// TestQosMiddleware tests that qos levels get properly transmitted.
+func TestQosMiddleware(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Can't be zero because that'd be an empty offset.
+	clock := hlc.NewClock(timeutil.Unix(0, 1).UnixNano, time.Nanosecond)
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+
+	// Shared cluster ID by all RPC peers (this ensures that the peers
+	// don't talk to servers from unrelated tests by accident).
+	clusterID := uuid.MakeV4()
+
+	serverCtx := newTestContext(clusterID, clock, stopper)
+	const serverNodeID = 1
+	serverCtx.NodeID.Set(context.TODO(), serverNodeID)
+	s := newTestServer(t, serverCtx,
+		grpc.UnaryInterceptor(qosServerInterceptor(nil /* prevUnaryInterceptor */)))
+
+	heartbeat := &ManualHeartbeatService{
+		ready:              make(chan error),
+		stopper:            stopper,
+		clock:              clock,
+		remoteClockMonitor: serverCtx.RemoteClocks,
+		version:            serverCtx.version,
+		nodeID:             &serverCtx.NodeID,
+	}
+	RegisterHeartbeatServer(s, heartbeat)
+	type qosLevel struct {
+		qos.Level
+		ok bool
+	}
+	qosLevelChan := make(chan qosLevel, 1)
+	batchFunc := internalServerFunc(func(
+		ctx context.Context, ba *roachpb.BatchRequest,
+	) (*roachpb.BatchResponse, error) {
+		l, ok := qos.LevelFromContext(ctx)
+		qosLevelChan <- qosLevel{l, ok}
+		return &roachpb.BatchResponse{}, nil
+	})
+	roachpb.RegisterInternalServer(s, batchFunc)
+
+	ln, err := netutil.ListenAndServeGRPC(serverCtx.Stopper, s, util.TestAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteAddr := ln.Addr().String()
+
+	clientCtx := newTestContext(clusterID, clock, stopper)
+	// Make the interval shorter to speed up the test.
+	clientCtx.heartbeatInterval = 1 * time.Millisecond
+	go func() { heartbeat.ready <- nil }()
+	conn, err := clientCtx.GRPCDialNode(remoteAddr, serverNodeID).Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the connection & successful heartbeat.
+	testutils.SucceedsSoon(t, func() error {
+		err := clientCtx.TestingConnHealth(remoteAddr, serverNodeID)
+		if err != nil && err != ErrNotHeartbeated {
+			t.Fatal(err)
+		}
+		return err
+	})
+	clientConn := roachpb.NewInternalClient(conn)
+
+	t.Run("without", func(t *testing.T) {
+		ctx := context.Background()
+		if _, err = clientConn.Batch(ctx, &roachpb.BatchRequest{}); err != nil {
+			t.Fatal(err)
+		}
+		got := <-qosLevelChan
+		if got.ok {
+			t.Fatalf("received context should not have contained a qos level")
+		}
+	})
+	t.Run("with", func(t *testing.T) {
+		l := qos.Level{Class: qos.ClassLow, Shard: 12}
+		ctx := qos.ContextWithLevel(context.Background(), l)
+		if _, err = clientConn.Batch(ctx, &roachpb.BatchRequest{}); err != nil {
+			t.Fatal(err)
+		}
+		got := <-qosLevelChan
+		if !got.ok {
+			t.Fatalf("expected context to have contained a qos level")
+		} else if got.Level != l {
+			t.Fatalf("expected context to have qos level %v, got %v", l, got.Level)
+		}
+	})
+	t.Run("malformed header", func(t *testing.T) {
+		ctxWithMalformedHeader := metadata.AppendToOutgoingContext(context.Background(),
+			clientQosLevelKey, "foo")
+		var entry *log.Entry
+		log.Intercept(ctxWithMalformedHeader, func(le log.Entry) {
+			if entry == nil && le.Severity == log.Severity_ERROR {
+				entry = &le
+			}
+		})
+		if _, err = clientConn.Batch(ctxWithMalformedHeader, &roachpb.BatchRequest{}); err != nil {
+			t.Fatal(err)
+		}
+		log.Intercept(ctxWithMalformedHeader, nil)
+		got := <-qosLevelChan
+		if got.ok {
+			t.Fatalf("expected context to not have contained a qos level")
+		}
+		const msg = "malformed qos level c_qos header: "
+		if entry == nil {
+			t.Fatalf("expected a log entry to be captured")
+		} else if !strings.Contains(entry.Message, msg) {
+			t.Fatalf("Found log entry %q, expected a log entrying containing %q", entry.Message, msg)
+		}
+	})
+	t.Run("extra headers", func(t *testing.T) {
+		l1 := qos.Level{Class: qos.ClassLow, Shard: 1}
+		l2 := qos.Level{Class: qos.ClassHigh, Shard: 2}
+		ctxWithDuplicateInHeader := metadata.AppendToOutgoingContext(context.Background(),
+			clientQosLevelKey, l1.EncodeString())
+		ctxWithDuplicateInHeader = metadata.AppendToOutgoingContext(ctxWithDuplicateInHeader,
+			clientQosLevelKey, l2.EncodeString())
+		var entry *log.Entry
+		log.Intercept(ctxWithDuplicateInHeader, func(le log.Entry) {
+			if entry == nil && le.Severity == log.Severity_WARNING {
+				entry = &le
+			}
+		})
+		if _, err = clientConn.Batch(ctxWithDuplicateInHeader, &roachpb.BatchRequest{}); err != nil {
+			t.Fatal(err)
+		}
+		log.Intercept(ctxWithDuplicateInHeader, nil)
+		const msg = "unexpected multiple qos levels"
+		if entry == nil {
+			t.Fatalf("expected a log entry to be captured")
+		} else if !strings.Contains(entry.Message, msg) {
+			t.Fatalf("Found log entry %q, expected a log entrying containing %q", entry.Message, msg)
+		}
+		// Check that the used level corresponds to the first value, which in this
+		// case is l1.
+		got := <-qosLevelChan
+		if !got.ok {
+			t.Fatalf("expected context to have contained a qos level")
+		} else if got.Level != l1 {
+			t.Fatalf("expected context to have qos level %v, got %v", l1, got.Level)
+		}
+	})
+}


### PR DESCRIPTION
A controller is a data structure to determine whether a request at a given
qos.Level can proceed. The AdmitAt call will either admit, block, or reject
a given request. The controller ticks periodically which adjusts its level
in response to traffic in the previous interval and feedback from a configured
overload signal.

This first implementation is likely too sensitive due to the small amount of
history it preserves. I suspect this will get more sophisticated over time.

Release note: None